### PR TITLE
Only walk component tree for when injected into a Component

### DIFF
--- a/addon/-private/find-parent-provider.ts
+++ b/addon/-private/find-parent-provider.ts
@@ -1,10 +1,16 @@
-import { IEmberObjectWithParentView, IProviderKlass } from './interfaces';
-import { Provider } from '../index';
+import Component from '@ember/component';
 import EmberObject from '@ember/object';
+
+import { IProviderKlass } from './interfaces';
+import { Provider } from '../index';
+
+type ComponentWithParentView = Component & {
+  parentView?: Component;
+};
 
 export default function findParentProvider(
   injectedProviders: WeakMap<EmberObject, Provider[]>,
-  component: IEmberObjectWithParentView,
+  component: ComponentWithParentView,
   ProviderKlass: IProviderKlass
 ): Provider | undefined {
   if (component.parentView) {

--- a/addon/-private/interfaces.ts
+++ b/addon/-private/interfaces.ts
@@ -1,11 +1,5 @@
-import EmberObject from '@ember/object';
-
 import { Provider } from '../index';
 
 export interface IProviderKlass extends Function {
   create: (...opts: object[]) => Provider;
-}
-
-export interface IEmberObjectWithParentView extends EmberObject {
-  parentView?: IEmberObjectWithParentView;
 }

--- a/addon/-private/provider-injection.ts
+++ b/addon/-private/provider-injection.ts
@@ -1,4 +1,5 @@
 import { getOwner } from '@ember/application';
+import Component from '@ember/component';
 import EmberObject from '@ember/object';
 import ComputedProperty from '@ember/object/computed';
 import { addListener } from '@ember/object/events';
@@ -28,17 +29,16 @@ class ProviderInjection<K extends keyof Registry> extends ComputedProperty<
       let provider: Provider;
       let isOwner = true;
 
-      const possibleProvider = findParentProvider(
-        INJECTED_PROVIDERS,
-        this,
-        ProviderKlass
-      );
+      const possibleProvider =
+        this instanceof Component
+          ? findParentProvider(INJECTED_PROVIDERS, this, ProviderKlass)
+          : undefined;
 
-      if (!possibleProvider) {
-        provider = ProviderKlass.create(owner.ownerInjection());
-      } else {
+      if (possibleProvider) {
         isOwner = false;
         provider = possibleProvider;
+      } else {
+        provider = ProviderKlass.create(owner.ownerInjection());
       }
 
       if (isOwner) {


### PR DESCRIPTION
This starts to add the pattern of looking up a "parent" differently based on the type of the object being injected into, or not at all.

Related to #7 