### PR TITLE
feat: create component for looking up a provider

### DIFF
--- a/addon/components/get-provider.js
+++ b/addon/components/get-provider.js
@@ -1,0 +1,27 @@
+import Component from '@ember/component';
+import { assert } from '@ember/debug';
+import { defineProperty } from '@ember/object';
+import { inject } from 'ember-provider';
+
+import layout from '../templates/components/get-provider';
+
+const GetProvider = Component.extend({
+  layout,
+
+  provider: undefined,
+  providerInstance: undefined,
+
+  init() {
+    this._super(...arguments);
+
+    assert('A `provider` property must be present', !!this.provider);
+
+    defineProperty(this, 'providerInstance', inject(this.provider));
+  }
+});
+
+GetProvider.reopenClass({
+  positionalParams: ['provider']
+});
+
+export default GetProvider;

--- a/addon/templates/components/get-provider.hbs
+++ b/addon/templates/components/get-provider.hbs
@@ -1,0 +1,1 @@
+{{yield providerInstance}}

--- a/app/components/get-provider.js
+++ b/app/components/get-provider.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-provider/components/get-provider';

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.1.2",
+    "ember-cli-htmlbars": "^3.0.0",
     "ember-cli-typescript": "^2.0.0-beta.3",
     "ember-compatibility-helpers": "^1.1.2"
   },
@@ -37,7 +38,6 @@
     "broccoli-asset-rev": "^2.7.0",
     "ember-cli": "~3.5.0",
     "ember-cli-dependency-checker": "^3.0.0",
-    "ember-cli-htmlbars": "^3.0.0",
     "ember-cli-htmlbars-inline-precompile": "^1.0.3",
     "ember-cli-inject-live-reload": "^1.8.2",
     "ember-cli-sri": "^2.1.1",

--- a/tests/dummy/app/components/get-provider.js
+++ b/tests/dummy/app/components/get-provider.js
@@ -1,0 +1,4 @@
+import GetProvider from 'ember-provider/components/get-provider';
+import NotifyOnInit from '../mixins/notify-on-init';
+
+export default GetProvider.extend(NotifyOnInit);

--- a/tests/dummy/app/components/inject-and-render-provider.js
+++ b/tests/dummy/app/components/inject-and-render-provider.js
@@ -1,0 +1,11 @@
+import Component from '@ember/component';
+import { inject as provider } from 'ember-provider';
+
+import NotifyOnInit from '../mixins/notify-on-init';
+import layout from '../templates/components/inject-and-render-provider';
+
+export default Component.extend(NotifyOnInit, {
+  layout,
+
+  dummy: provider('dummy')
+});

--- a/tests/dummy/app/templates/components/inject-and-render-provider.hbs
+++ b/tests/dummy/app/templates/components/inject-and-render-provider.hbs
@@ -1,0 +1,1 @@
+{{get-provider provider='dummy' onInit=(action onGetProviderInit)}}

--- a/tests/integration/components/get-provider-test.js
+++ b/tests/integration/components/get-provider-test.js
@@ -1,0 +1,89 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { Provider } from 'ember-provider';
+
+module('Integration | Component | get-provider', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.set('onInit', (type, context) => {
+      this.set(type, context);
+    });
+
+    this.owner.register(
+      'provider:dummy',
+      class extends Provider {
+        constructor() {
+          super(...arguments);
+
+          this.name = 'Foo Bar';
+        }
+      }
+    );
+  });
+
+  test('looking up a provider', async function(assert) {
+    await render(hbs`
+      {{#get-provider provider='dummy' as |provider|}}
+        {{provider.name}}
+      {{/get-provider}}
+    `);
+
+    assert.dom().hasText('Foo Bar', 'Yields the correct provider');
+  });
+
+  test('using a positional param', async function(assert) {
+    await render(hbs`
+      {{#get-provider 'dummy' as |provider|}}
+        {{provider.name}}
+      {{/get-provider}}
+    `);
+
+    assert.dom().hasText('Foo Bar', 'Yields the correct provider');
+  });
+
+  test('looking up a parent provider', async function(assert) {
+    await render(hbs`
+      {{#parent-component onInit=(action onInit 'parent')}} 
+        {{get-provider 'current-user' onInit=(action onInit 'getProvider')}}
+      {{/parent-component}}
+    `);
+
+    assert.equal(
+      this.parent.get('currentUser'),
+      this.getProvider.get('providerInstance'),
+      'Components are sharing the same provider instance'
+    );
+  });
+
+  test('creating provider for child component', async function(assert) {
+    await render(hbs`
+      {{#get-provider 'current-user' onInit=(action onInit 'getProvider') as |provider|}}
+        {{child-component onInit=(action onInit 'child')}}
+      {{/get-provider}}
+    `);
+
+    assert.equal(
+      this.getProvider.get('providerInstance'),
+      this.child.get('currentUser'),
+      'Components are sharing the same provider instance'
+    );
+  });
+
+  test('getting a provider from the current context', async function(assert) {
+    await render(hbs`
+      {{inject-and-render-provider
+          onInit=(action onInit 'parent')
+          onGetProviderInit=(action onInit 'getProvider')
+      }} 
+    `);
+
+    assert.equal(
+      this.parent.get('dummy'),
+      this.getProvider.get('providerInstance'),
+      'Components are sharing the same provider instance'
+    );
+  });
+});


### PR DESCRIPTION
This removes the fact that provider access was not possible in the template without having to inject a provider into your component manually.

Now, using `get-provider`, you can look up a provider and yield a reference to it, useful if you want to pass that object into another component that you do not want to modify.